### PR TITLE
Add custom tags into CustomField3

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,0 +1,15 @@
+Spree::Order.class_eval do
+  def custom_tags
+    tags = []
+
+    if respond_to?(:subscription?) && subscription?
+      tags << :subscription
+    end
+
+    if respond_to?(:new_order_for_email?) && new_order_for_email?
+      tags << :first_order
+    end
+
+    tags
+  end
+end

--- a/app/views/spree/shipstation/export.xml.builder
+++ b/app/views/spree/shipstation/export.xml.builder
@@ -52,6 +52,10 @@ xml.Orders(pages: (@shipments.total_count/50.0).ceil) {
       xml.CustomField2   shipment.number
 
 
+      unless order.custom_tags.empty?
+        xml.CustomField3 order.custom_tags.join(",")
+      end
+
 =begin
       if order.gift?
         xml.Gift

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+describe Spree::Order do
+  before :each do
+    allow(subject).to receive(:new_order_for_email?).and_return false
+    allow(subject).to receive(:subscription?).and_return nil
+  end
+
+  it "has no custom tags by default" do
+    expect(subject.custom_tags).to eq []
+  end
+
+  it "has the tag 'first-order' if new_order_for_email?" do
+    allow(subject).to receive(:new_order_for_email?).and_return true
+    expect(subject.custom_tags).to eq [:first_order]
+  end
+
+  it "has the tag 'subscription' if subscription? is true?" do
+    allow(subject).to receive(:subscription?).and_return true
+    expect(subject.custom_tags).to eq [:subscription]
+  end
+end


### PR DESCRIPTION
covers "first_order" and "subscription" use cases, only if order object passed to the exported has a custom_tags method

https://app.asana.com/0/221747295457/150494522641450
https://app.asana.com/0/221747295457/163963330385549
